### PR TITLE
Added output directory to idlcxx (#418)

### DIFF
--- a/src/idlcxx/Generate.cmake
+++ b/src/idlcxx/Generate.cmake
@@ -11,7 +11,7 @@
 #
 
 function(IDLCXX_GENERATE)
-  set(one_value_keywords TARGET DEFAULT_EXTENSIBILITY OUTPUT_DIR)
+  set(one_value_keywords TARGET DEFAULT_EXTENSIBILITY BASE_DIR OUTPUT_DIR)
   set(multi_value_keywords FILES FEATURES INCLUDES WARNINGS)
   cmake_parse_arguments(
     IDLCXX "" "${one_value_keywords}" "${multi_value_keywords}" "" ${ARGN})
@@ -34,6 +34,7 @@ function(IDLCXX_GENERATE)
 
   idlc_generate_generic(TARGET ${IDLCXX_TARGET}
     BACKEND ${_idlcxx_shared_lib}
+    BASE_DIR ${IDLCXX_BASE_DIR}
     FILES ${IDLCXX_FILES}
     FEATURES ${IDLCXX_FEATURES}
     INCLUDES ${IDLCXX_INCLUDES}

--- a/src/idlcxx/src/generator.c
+++ b/src/idlcxx/src/generator.c
@@ -971,72 +971,35 @@ __declspec(dllexport)
 idl_retcode_t generate(const idl_pstate_t *pstate, const idlc_generator_config_t *config)
 {
   idl_retcode_t ret = IDL_RETCODE_NO_MEMORY;
-  char *dir = NULL, *basename = NULL, *empty = "";
-  const char *sep, *ext, *file, *path;
   struct generator gen;
 
   assert(pstate->paths);
   assert(pstate->paths->name);
-  path = pstate->sources->path->name;
-  assert(path);
-
-  /* use relative directory if user provided a relative path, use current
-     word directory otherwise */
-  sep = ext = NULL;
-  for (const char *ptr = path; ptr[0]; ptr++) {
-    if (idl_isseparator((unsigned char)ptr[0]) && ptr[1] != '\0')
-      sep = ptr;
-    else if (ptr[0] == '.')
-      ext = ptr;
-  }
-
-  file = sep ? sep + 1 : path;
-  if (idl_isabsolute(path) || !sep)
-    dir = empty;
-  else if (!(dir = idl_strndup(path, (size_t)(sep-path))))
-    goto err_dir;
-  if (!(basename = idl_strndup(file, ext ? (size_t)(ext-file) : strlen(file))))
-    goto err_basename;
-
-  /* replace backslashes by forward slashes */
-  for (char *ptr = dir; *ptr; ptr++) {
-    if (*ptr == '\\')
-      *ptr = '/';
-  }
+  assert(config);
 
   memset(&gen, 0, sizeof(gen));
-  gen.path = file;
+  gen.path = pstate->sources->path->name;
   gen.config = config;
 
-  sep = dir[0] == '\0' ? "" : "/";
-  if (idl_asprintf(&gen.header.path, "%s%s%s.hpp", dir, sep, basename) < 0)
-    goto err_hdr;
-  if (!(gen.header.handle = idl_fopen(gen.header.path, "wb")))
-    goto err_hdr_fh;
-  if (idl_asprintf(&gen.impl.path, "%s%s%s.cpp", dir, sep, basename) < 0)
-    goto err_impl;
-  if (!(gen.impl.handle = idl_fopen(gen.impl.path, "wb")))
-    goto err_impl_fh;
+  /* generate output filenames and open output files */
+  if (idl_generate_out_file(gen.path, config->output_dir, config->base_dir, "hpp", &gen.header.path, false) < 0 ||
+      idl_generate_out_file(gen.path, config->output_dir, config->base_dir, "cpp", &gen.impl.path, false) < 0 ||
+      !(gen.header.handle = idl_fopen(gen.header.path, "wb")) ||
+      !(gen.impl.handle = idl_fopen(gen.impl.path, "wb")))
+    goto err;
 
   /* generate format strings from templates */
-  if (makefmtp(&gen.array_format, arr_tmpl, arr_toks, arr_flags) < 0)
-    goto err_arr;
-  if (makefmtp(&gen.sequence_format, seq_tmpl, seq_toks, seq_flags) < 0)
-    goto err_seq;
-  if (makefmtp(&gen.bounded_sequence_format, bnd_seq_tmpl, bnd_seq_toks, bnd_seq_flags) < 0)
-    goto err_bnd_seq;
-  if (makefmtp(&gen.string_format, str_tmpl, NULL, NULL) < 0)
-    goto err_str;
-  if (makefmtp(&gen.bounded_string_format, bnd_str_tmpl, bnd_str_toks, bnd_str_flags) < 0)
-    goto err_bnd_str;
-  if (makefmtp(&gen.optional_format, opt_tmpl, NULL, NULL) < 0)
-    goto err_opt;
-  if (makefmtp(&gen.external_format, ext_tmpl, NULL, NULL) < 0)
-    goto err_ext;
-  if (makefmtp(&gen.union_format, uni_tmpl, NULL, NULL) < 0)
-    goto err_uni;
-  if (makefmtp(&gen.union_getter_format, uni_get_tmpl, NULL, NULL) < 0)
-    goto err_uni_get;
+  if (makefmtp(&gen.array_format, arr_tmpl, arr_toks, arr_flags) < 0 ||
+      makefmtp(&gen.sequence_format, seq_tmpl, seq_toks, seq_flags) < 0 ||
+      makefmtp(&gen.bounded_sequence_format, bnd_seq_tmpl, bnd_seq_toks, bnd_seq_flags) < 0 ||
+      makefmtp(&gen.string_format, str_tmpl, NULL, NULL) < 0 ||
+      makefmtp(&gen.bounded_string_format, bnd_str_tmpl, bnd_str_toks, bnd_str_flags) < 0 ||
+      makefmtp(&gen.optional_format, opt_tmpl, NULL, NULL) < 0 ||
+      makefmtp(&gen.external_format, ext_tmpl, NULL, NULL) < 0 ||
+      makefmtp(&gen.union_format, uni_tmpl, NULL, NULL) < 0 ||
+      makefmtp(&gen.union_getter_format, uni_get_tmpl, NULL, NULL) < 0)
+    goto err;
+
   /* copy include directives verbatim */
   gen.array_include = arr_inc;
   gen.sequence_include = seq_inc;
@@ -1047,39 +1010,37 @@ idl_retcode_t generate(const idl_pstate_t *pstate, const idlc_generator_config_t
   gen.union_include = uni_inc;
   gen.external_include = ext_inc;
 
+  /* invoke code generation */
   ret = generate_nosetup(pstate, &gen);
 
-  free(gen.union_getter_format);
-err_uni_get:
-  free(gen.union_format);
-err_uni:
-  free(gen.external_format);
-err_ext:
-  free(gen.optional_format);
-err_opt:
-  free(gen.bounded_string_format);
-err_bnd_str:
-  free(gen.string_format);
-err_str:
-  free(gen.bounded_sequence_format);
-err_bnd_seq:
-  free(gen.sequence_format);
-err_seq:
-  free(gen.array_format);
-err_arr:
-  fclose(gen.impl.handle);
-err_impl_fh:
-  free(gen.impl.path);
-err_impl:
-  fclose(gen.header.handle);
-err_hdr_fh:
-  free(gen.header.path);
-err_hdr:
-  free(basename);
-err_basename:
-  if (dir && dir != empty)
-    free(dir);
-err_dir:
+err:
+  /* cleanup */
+  if (gen.union_getter_format)
+    free(gen.union_getter_format);
+  if (gen.union_format)
+    free(gen.union_format);
+  if (gen.external_format)
+    free(gen.external_format);
+  if (gen.optional_format)
+    free(gen.optional_format);
+  if (gen.bounded_string_format)
+    free(gen.bounded_string_format);
+  if (gen.string_format)
+    free(gen.string_format);
+  if (gen.bounded_sequence_format)
+    free(gen.bounded_sequence_format);
+  if (gen.sequence_format)
+    free(gen.sequence_format);
+  if (gen.array_format)
+    free(gen.array_format);
+  if (gen.impl.path)
+    free(gen.impl.path);
+  if (gen.header.path)
+    free(gen.header.path);
+  if (gen.impl.handle)
+    fclose(gen.impl.handle);
+  if (gen.header.handle)
+    fclose(gen.header.handle);
   return ret;
 }
 


### PR DESCRIPTION
* Added output directory to idlcxx

The output directory parameter was not being used in when passed from idlc compiler to idlcxx library
Fixed so the output directory is now used in idlcxx This should fix issue #413



* Added BASE_DIR support to idlcxx

In the CMake idlcxx_generate function, the parameter BASE_DIR was not supported, unlike its CycloneDDS-C counterpart, this has been added Also changed the output filename/path generation to also support base directory restructuring and to more closely match CycloneDDS-C generation
This PR should now also fix issues #383 and #417



* Restructured error handling in code generator

Restructured handling of error cases to ensure cleanup of all assigned memory, since the code analyzer was thinking that the makefmtp function returning < 0 could still have assigned memory on the heap, while this is not the case, the code analyzer did not look that deeply



---------