### PR TITLE
Fix missing Writer callbacks on DomainParticipantListener

### DIFF
--- a/src/ddscxx/include/dds/sub/detail/TDataReaderImpl.hpp
+++ b/src/ddscxx/include/dds/sub/detail/TDataReaderImpl.hpp
@@ -532,55 +532,6 @@ dds::sub::detail::DataReader<T>::init(ObjectDelegate::weak_ref_type weak_ref)
     /* Add the datareader to the datareader set of the subscriber */
     this->sub_.delegate()->add_datareader(*this);
 
-    // Because listeners are added after reader is created (which is in enabled state, because
-    // disabled state is not yet supported), events could have occured before listeners were
-    // registered. Therefore the event handlers for those events are called here.
-    if (this->listener_get()) {
-        dds::core::status::StatusMask readerStatus = status_changes();
-
-        if (listener_mask.to_ulong() & dds::core::status::StatusMask::data_available().to_ulong()
-                && readerStatus.test(DDS_DATA_AVAILABLE_STATUS_ID))
-        {
-            on_data_available(this->ddsc_entity);
-        }
-        if (listener_mask.to_ulong() & dds::core::status::StatusMask::liveliness_changed().to_ulong()
-                && readerStatus.test(DDS_LIVELINESS_CHANGED_STATUS_ID))
-        {
-            dds::core::status::LivelinessChangedStatus status = liveliness_changed_status();
-            on_liveliness_changed(this->ddsc_entity, status);
-        }
-        if (listener_mask.to_ulong() & dds::core::status::StatusMask::requested_deadline_missed().to_ulong()
-                && readerStatus.test(DDS_REQUESTED_DEADLINE_MISSED_STATUS_ID))
-        {
-            dds::core::status::RequestedDeadlineMissedStatus status = requested_deadline_missed_status();
-            on_requested_deadline_missed(this->ddsc_entity, status);
-        }
-        if (listener_mask.to_ulong() & dds::core::status::StatusMask::requested_incompatible_qos().to_ulong()
-                && readerStatus.test(DDS_REQUESTED_INCOMPATIBLE_QOS_STATUS_ID))
-        {
-            dds::core::status::RequestedIncompatibleQosStatus status = requested_incompatible_qos_status();
-            on_requested_incompatible_qos(this->ddsc_entity, status);
-        }
-        if (listener_mask.to_ulong() & dds::core::status::StatusMask::sample_lost().to_ulong()
-                && readerStatus.test(DDS_SAMPLE_LOST_STATUS_ID))
-        {
-            dds::core::status::SampleLostStatus status = sample_lost_status();
-            on_sample_lost(this->ddsc_entity, status);
-        }
-        if (listener_mask.to_ulong() & dds::core::status::StatusMask::sample_rejected().to_ulong()
-                && readerStatus.test(DDS_SAMPLE_REJECTED_STATUS_ID))
-        {
-            dds::core::status::SampleRejectedStatus status = sample_rejected_status();
-            on_sample_rejected(this->ddsc_entity, status);
-        }
-        if (listener_mask.to_ulong() & dds::core::status::StatusMask::subscription_matched().to_ulong()
-                && readerStatus.test(DDS_SUBSCRIPTION_MATCHED_STATUS_ID))
-        {
-            dds::core::status::SubscriptionMatchedStatus status = subscription_matched_status();
-            on_subscription_matched(this->ddsc_entity, status);
-        }
-    }
-
     this->enable();
 }
 

--- a/src/ddscxx/include/org/eclipse/cyclonedds/domain/DomainParticipantDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/domain/DomainParticipantDelegate.hpp
@@ -161,7 +161,14 @@ public:
         org::eclipse::cyclonedds::core::SubscriptionMatchedStatusDelegate &sd);
     void on_sample_lost(dds_entity_t reader,
         org::eclipse::cyclonedds::core::SampleLostStatusDelegate &sd);
-
+    void on_offered_deadline_missed(dds_entity_t writer,
+          org::eclipse::cyclonedds::core::OfferedDeadlineMissedStatusDelegate &sd);
+    void on_offered_incompatible_qos(dds_entity_t writer,
+          org::eclipse::cyclonedds::core::OfferedIncompatibleQosStatusDelegate &sd);
+    void on_liveliness_lost(dds_entity_t writer,
+          org::eclipse::cyclonedds::core::LivelinessLostStatusDelegate &sd);
+    void on_publication_matched(dds_entity_t writer,
+          org::eclipse::cyclonedds::core::PublicationMatchedStatusDelegate &sd);
 
 private:
     static org::eclipse::cyclonedds::core::EntitySet participants;

--- a/src/ddscxx/src/org/eclipse/cyclonedds/domain/DomainParticipantDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/domain/DomainParticipantDelegate.cpp
@@ -732,3 +732,59 @@ void org::eclipse::cyclonedds::domain::DomainParticipantDelegate::on_sample_lost
 
     this->listener()->on_sample_lost(adr, s);
 }
+
+void org::eclipse::cyclonedds::domain::DomainParticipantDelegate::on_offered_deadline_missed(dds_entity_t writer,
+        org::eclipse::cyclonedds::core::OfferedDeadlineMissedStatusDelegate &sd)
+{
+    org::eclipse::cyclonedds::pub::AnyDataWriterDelegate::ref_type ref =
+           ::std::dynamic_pointer_cast<org::eclipse::cyclonedds::pub::AnyDataWriterDelegate>(
+                this->extract_strong_ref(writer));
+    dds::pub::AnyDataWriter adw(ref);
+
+    dds::core::status::OfferedDeadlineMissedStatus s;
+    s.delegate() = sd;
+
+    this->listener()->on_offered_deadline_missed(adw, s);
+}
+
+void org::eclipse::cyclonedds::domain::DomainParticipantDelegate::on_offered_incompatible_qos(dds_entity_t writer,
+        org::eclipse::cyclonedds::core::OfferedIncompatibleQosStatusDelegate &sd)
+{
+    org::eclipse::cyclonedds::pub::AnyDataWriterDelegate::ref_type ref =
+            ::std::dynamic_pointer_cast<org::eclipse::cyclonedds::pub::AnyDataWriterDelegate>(
+                this->extract_strong_ref(writer));
+    dds::pub::AnyDataWriter adw(ref);
+
+    dds::core::status::OfferedIncompatibleQosStatus s;
+    s.delegate() = sd;
+
+    this->listener()->on_offered_incompatible_qos(adw, s);
+}
+
+void org::eclipse::cyclonedds::domain::DomainParticipantDelegate::on_liveliness_lost(dds_entity_t writer,
+        org::eclipse::cyclonedds::core::LivelinessLostStatusDelegate &sd)
+{
+    org::eclipse::cyclonedds::pub::AnyDataWriterDelegate::ref_type ref =
+            ::std::dynamic_pointer_cast<org::eclipse::cyclonedds::pub::AnyDataWriterDelegate>(
+                this->extract_strong_ref(writer));
+    dds::pub::AnyDataWriter adw(ref);
+
+    dds::core::status::LivelinessLostStatus s;
+    s.delegate() = sd;
+
+    this->listener()->on_liveliness_lost(adw, s);
+}
+
+void org::eclipse::cyclonedds::domain::DomainParticipantDelegate::on_publication_matched(dds_entity_t writer,
+        org::eclipse::cyclonedds::core::PublicationMatchedStatusDelegate &sd)
+{
+    org::eclipse::cyclonedds::pub::AnyDataWriterDelegate::ref_type ref =
+            ::std::dynamic_pointer_cast<org::eclipse::cyclonedds::pub::AnyDataWriterDelegate>(
+                this->extract_strong_ref(writer));
+    dds::pub::AnyDataWriter adw(ref);
+
+    dds::core::status::PublicationMatchedStatus s;
+    s.delegate() = sd;
+
+    this->listener()->on_publication_matched(adw, s);
+}


### PR DESCRIPTION
When setting a Listener on the DomainParticipant that needs to handle events originating at a DataWriter, the application ignores (or crashes in debug mode) the Writer event when it occurs. This was caused by the DomainParticipant class not overriding the default Listener callback handler set in the Entity class that was meant as an abstract placeholder and caused an assertion to fail. That is now resolved by properly overriding this placeholder with a callback handler that properly propagates the callback to the appropriate function in the registered DomainParticipantListener. This should fix issue #427